### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided


### PR DESCRIPTION
Potential fix for [https://github.com/W0n9/BUCTNet-Login/security/code-scanning/5](https://github.com/W0n9/BUCTNet-Login/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow only reads repository contents (e.g., checking out code), we will set `contents: read`. This ensures that the workflow has the least privileges necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
