### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,6 +5,8 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Deploy
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/W0n9/BUCTNet-Login/security/code-scanning/4](https://github.com/W0n9/BUCTNet-Login/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow uses `softprops/action-gh-release@v2` to create a release, it needs `contents: write` permission. For all other operations (e.g., building binaries), no additional permissions are required. Setting `contents: write` ensures the workflow has the minimum necessary permissions to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
