### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
     # strategy:
     #   matrix:
     #     os: [ ubuntu-latest ]


### PR DESCRIPTION
Potential fix for [https://github.com/W0n9/BUCTNet-Login/security/code-scanning/7](https://github.com/W0n9/BUCTNet-Login/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Since this is a release workflow, it likely requires `contents: write` to create releases and manage tags. We will also include `contents: read` to allow the workflow to read repository contents. These permissions will be added at the job level to ensure they are scoped specifically to the `release` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
